### PR TITLE
fix - android - send - params type should be a string instead of map

### DIFF
--- a/android/src/main/java/com/sap/gigya_rn_plugin/GigyaSdkModule.java
+++ b/android/src/main/java/com/sap/gigya_rn_plugin/GigyaSdkModule.java
@@ -10,8 +10,6 @@ import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
 import com.gigya.android.sdk.account.models.GigyaAccount;
 
-import java.util.HashMap;
-
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -51,8 +49,8 @@ public class GigyaSdkModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void send(@Nonnull String api, @Nullable ReadableMap params, Promise promise) {
-        gigyaSdk.send(api, params == null ? new HashMap<>() : params.toHashMap(), promise);
+    public void send(@Nonnull String api, @Nonnull String params, Promise promise) {
+        gigyaSdk.send(api, params, promise);
     }
 
     @ReactMethod

--- a/android/src/main/java/com/sap/gigya_rn_plugin/GigyaSdkWrapper.java
+++ b/android/src/main/java/com/sap/gigya_rn_plugin/GigyaSdkWrapper.java
@@ -68,14 +68,10 @@ public class GigyaSdkWrapper<T extends GigyaAccount> {
         gigyaInstance.init(apikey, apiDomain);
     }
 
-    void send(String api, Map<String, Object> parameters, Promise promise) {
+    void send(String api, String jsonParameters, Promise promise) {
         GigyaSdkRNLogger.log("send: called");
         promiseWrapper.promise = promise;
-        if (parameters == null) {
-            parameters = new HashMap<>();
-        }
-        gigyaInstance.send(api, parameters, new GigyaCallback<GigyaApiResponse>() {
-            @Override
+        gigyaInstance.send(api, mapParams(jsonParameters), new GigyaCallback<GigyaApiResponse>() {            @Override
             public void onSuccess(GigyaApiResponse gigyaApiResponse) {
                 GigyaSdkRNLogger.log("send: success with response: " + gigyaApiResponse.asJson());
                 promiseWrapper.resolve(gigyaApiResponse);


### PR DESCRIPTION
Fix inconsistent `send` parameters for android. Should be expecting parameters serialized into a string instead of a map.

See https://github.com/SAP/gigya-react-native-plugin-for-sap-customer-data-cloud/issues/6 for more details.